### PR TITLE
TEST add range check for random forest regressor

### DIFF
--- a/sklearn/ensemble/tests/test_forest.py
+++ b/sklearn/ensemble/tests/test_forest.py
@@ -1367,3 +1367,22 @@ def test_little_tree_with_small_max_samples(ForestClass):
 
     msg = "Tree without `max_samples` restriction should have more nodes"
     assert tree1.node_count > tree2.node_count, msg
+
+
+def test_rf_regressor_prediction_range():
+    # Given
+    rng = np.random.RandomState(42)
+    n_samples = 100
+    n_features = 10
+    X_train = rng.normal(size=(n_samples, n_features))
+    y_train = rng.normal(size=n_samples)
+    rfr = RandomForestRegressor(random_state=42)
+    rfr.fit(X_train, y_train)
+    target_min = np.min(y_train)
+    target_max = np.max(y_train)
+    X_test = rng.normal(size=(n_samples, n_features))
+    # When
+    y_preds = rfr.predict(X_test)
+    # Then
+    assert not (y_preds > target_max).any()
+    assert not (y_preds < target_min).any()


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Fake issue from Paris Sprint.

#### What does this implement/fix? Explain your changes.
This PR adds a `test_rf_regressor_prediction_range` test which checks if all predicted values fall in the range defined by the train set values.

#### Any other comments?

PEP8 compliance was checked with `git diff | flake8 --diff`.
<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
